### PR TITLE
Single use claimant executor

### DIFF
--- a/packages/shibboleth-js/src/index.ts
+++ b/packages/shibboleth-js/src/index.ts
@@ -54,15 +54,18 @@ function unrleZeros(data: Uint8Array): Uint8Array {
 
 export class ClaimCode {
     readonly validator: string;
-    readonly claimkey: Uint8Array;
+    readonly claimant: string;           
+    readonly claimkey: Uint8Array; 
     readonly authsig: Uint8Array;
     readonly data: Uint8Array;
+
 
     constructor(validator: string, claimkey: BytesLike, authsig: BytesLike, data: BytesLike) {
         this.validator = validator;
         this.claimkey = arrayify(claimkey);
         this.authsig = arrayify(authsig);
         this.data = arrayify(data);
+        this.claimant = computeAddress(claimkey);
     }
 
     static fromString(str: string): ClaimCode {

--- a/packages/validator/contracts/BaseExecutor.sol
+++ b/packages/validator/contracts/BaseExecutor.sol
@@ -19,7 +19,7 @@ abstract contract BaseExecutor is IExecutor, ERC165 {
         validator = _validator;
     }
 
-    function executeClaim(address /*issuer*/, address /*beneficiary*/, bytes calldata /*claimData*/, bytes calldata /*executorData*/) public virtual override {
+    function executeClaim(address /*issuer*/, address /*claimant*/, address /*beneficiary*/, bytes calldata /*claimData*/, bytes calldata /*executorData*/) public virtual override {
         if(msg.sender != validator) {
             revert NotAuthorisedError();
         }

--- a/packages/validator/contracts/BaseExecutor.sol
+++ b/packages/validator/contracts/BaseExecutor.sol
@@ -29,7 +29,7 @@ abstract contract BaseExecutor is IExecutor, ERC165 {
         return interfaceId == type(IExecutor).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    function metadata(address /*issuer*/, bytes calldata /*claimData*/, bytes calldata /*executorData*/) public override virtual view returns(string memory) {
+    function metadata(address /*issuer*/, address /*claimant*/, bytes calldata /*claimData*/, bytes calldata /*executorData*/) public override virtual view returns(string memory) {
         revert NotImplementedError();
     }
 }

--- a/packages/validator/contracts/HighestNonceExecutor.sol
+++ b/packages/validator/contracts/HighestNonceExecutor.sol
@@ -42,7 +42,7 @@ abstract contract HighestNonceExecutor is BaseExecutor {
      * @return A URL that resolves to JSON metadata as described in the spec.
      *         Callers must support at least 'data' and 'https' schemes.
      */
-    function metadata(address /*issuer*/, bytes calldata claimData, bytes calldata /*executorData*/) public override virtual view returns(string memory) {
+    function metadata(address /*issuer*/, address /*claimaint*/, bytes calldata claimData, bytes calldata /*executorData*/) public override virtual view returns(string memory) {
         uint64 claimNonce = abi.decode(claimData, (uint64));
         if(claimNonce < nonce) {
             return string(abi.encodePacked(

--- a/packages/validator/contracts/HighestNonceExecutor.sol
+++ b/packages/validator/contracts/HighestNonceExecutor.sol
@@ -22,12 +22,13 @@ abstract contract HighestNonceExecutor is BaseExecutor {
      *      was called by a registry they recognise, and that any conditions in claimData such as replay protection are met
      *      before acting on the request.
      * @param issuer The account that issued the claim.
+     * @param claimant The account that is entitled to make the claim.
      * @param beneficiary The account that the claim should benefit.
      * @param claimData Claim data provided by the issuer.
      * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      */
-    function executeClaim(address issuer, address beneficiary, bytes calldata claimData, bytes calldata executorData) public virtual override {
-        super.executeClaim(issuer, beneficiary, claimData, executorData);
+    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData, bytes calldata executorData) public virtual override {
+        super.executeClaim(issuer, claimant, beneficiary, claimData, executorData);
         uint64 claimNonce = abi.decode(claimData, (uint64));
         if(claimNonce < nonce) {
             revert NonceTooLow();

--- a/packages/validator/contracts/IExecutor.sol
+++ b/packages/validator/contracts/IExecutor.sol
@@ -26,10 +26,11 @@ interface IExecutor is IERC165 {
     /**
      * @dev Returns metadata explaining a claim.
      * @param issuer The address of the issuer.
+     * @param claimant The account that is entitled to make the claim.
      * @param claimData Claim data provided by the issuer.
      * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      * @return A URL that resolves to JSON metadata as described in the spec.
      *         Callers must support at least 'data' and 'https' schemes.
      */
-    function metadata(address issuer, bytes calldata claimData, bytes calldata executorData) external view returns(string memory);
+    function metadata(address issuer, address claimant,bytes calldata claimData, bytes calldata executorData) external view returns(string memory);
 }

--- a/packages/validator/contracts/IExecutor.sol
+++ b/packages/validator/contracts/IExecutor.sol
@@ -16,11 +16,12 @@ interface IExecutor is IERC165 {
      *      was called by a registry they recognise, and that any conditions in claimData such as replay protection are met
      *      before acting on the request.
      * @param issuer The account that issued the claim.
+     * @param claimant The account that is entitled to make the claim.
      * @param beneficiary The account that the claim should benefit.
      * @param claimData Claim data provided by the issuer.
      * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      */
-    function executeClaim(address issuer, address beneficiary, bytes calldata claimData, bytes calldata executorData) external;
+    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData, bytes calldata executorData) external;
 
     /**
      * @dev Returns metadata explaining a claim.

--- a/packages/validator/contracts/IValidator.sol
+++ b/packages/validator/contracts/IValidator.sol
@@ -20,9 +20,10 @@ interface IValidator is IERC165 {
     /**
      * @dev Returns metadata explaining a claim.
      * @param issuer The address of the issuer.
+     * @param claimant The account that is entitled to make the claim.
      * @param data Claim data provided by the issuer.
      * @return A URL that resolves to JSON metadata as described in the spec.
      *         Callers must support at least 'data' and 'https' schemes.
      */
-    function metadata(address issuer, bytes calldata data) external view returns(string memory);
+    function metadata(address issuer, address claimant, bytes calldata data) external view returns(string memory);
 }

--- a/packages/validator/contracts/SingleClaimantExecutor.sol
+++ b/packages/validator/contracts/SingleClaimantExecutor.sol
@@ -1,0 +1,50 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "./BaseExecutor.sol";
+import "@openzeppelin/contracts/contracts/utils/introspection/ERC165.sol";
+import "@openzeppelin/contracts/contracts/utils/Base64.sol";
+
+/**
+ * @dev An abstract implementation of an Executor that only allows claims with unique clamaints. 
+ *      To use, subclass and override `executeClaim` and `metadata`, being sure to call `super` inside `executeClaim` before doing anything else.
+ *      This executor expects the first 32 bytes of `claimData` to be the nonce; you may optionally use extra data for your own purposes.
+ */
+abstract contract SingleClaimantExecutor is BaseExecutor {
+
+    // claimant -> beneficiary
+    mapping (address => address) public claimants;
+    
+    error UsedClaimant();
+
+    constructor(address _validator) BaseExecutor(_validator) { }
+
+    /**
+     * @dev Executes a claim that has been verified by the `ValidatorRegistry`. Implementers must check that this function
+     *      was called by a registry they recognise, and that any conditions in claimData such as replay protection are met
+     *      before acting on the request.
+     * @param issuer The account that issued the claim.
+     * @param claimant The account that is entitled to make the claim.
+     * @param beneficiary The account that the claim should benefit.
+     * @param claimData Claim data provided by the issuer.
+     * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
+     */
+    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData, bytes calldata executorData) public virtual override {
+        super.executeClaim(issuer, claimant, beneficiary, claimData, executorData);
+
+        // if claimant was already used
+        if(claimants[claimant] != address(0)) {
+            revert UsedClaimant();
+        }
+        claimants[claimant] = beneficiary;
+    }
+
+    /**
+     * @dev Returns metadata explaining a claim. Subclasses should call this first and return it if it is nonempty.
+     * @return A URL that resolves to JSON metadata as described in the spec.
+     *         Callers must support at least 'data' and 'https' schemes.
+     */
+    function metadata(address /*issuer*/, bytes calldata /*claimData*/, bytes calldata /*executorData*/) public override virtual view returns(string memory) {
+        return "";
+    }    
+}

--- a/packages/validator/contracts/SingleClaimantExecutor.sol
+++ b/packages/validator/contracts/SingleClaimantExecutor.sol
@@ -36,5 +36,21 @@ abstract contract SingleClaimantExecutor is BaseExecutor {
             revert AlreadyClaimed();
         }
         claimants[claimant] = beneficiary;
+    }
+
+    /**
+     * @dev Returns metadata explaining a claim. Subclasses should call this first and return it if it is nonempty.
+     * @param claimant The account that is entitled to make the claim.
+     * @return A URL that resolves to JSON metadata as described in the spec.
+     *         Callers must support at least 'data' and 'https' schemes.
+     */
+    function metadata(address /*issuer*/, address claimant, bytes calldata /*claimData*/, bytes calldata /*executorData*/) public override virtual view returns(string memory) {
+      if(claimants[claimant] != address(0)) {
+        return string(abi.encodePacked(
+                                       "data:application/json;base64,",
+                                       Base64.encode("{\"valid\":false,\"error\":\"Code already claimed..\"}")
+                                       ));
+      }
+      return "";
     }    
 }

--- a/packages/validator/contracts/SingleClaimantExecutor.sol
+++ b/packages/validator/contracts/SingleClaimantExecutor.sol
@@ -8,14 +8,13 @@ import "@openzeppelin/contracts/contracts/utils/Base64.sol";
 /**
  * @dev An abstract implementation of an Executor that only allows claims with unique clamaints. 
  *      To use, subclass and override `executeClaim` and `metadata`, being sure to call `super` inside `executeClaim` before doing anything else.
- *      This executor expects the first 32 bytes of `claimData` to be the nonce; you may optionally use extra data for your own purposes.
  */
 abstract contract SingleClaimantExecutor is BaseExecutor {
 
     // claimant -> beneficiary
     mapping (address => address) public claimants;
     
-    error UsedClaimant();
+    error AlreadyClaimed();
 
     constructor(address _validator) BaseExecutor(_validator) { }
 
@@ -34,17 +33,8 @@ abstract contract SingleClaimantExecutor is BaseExecutor {
 
         // if claimant was already used
         if(claimants[claimant] != address(0)) {
-            revert UsedClaimant();
+            revert AlreadyClaimed();
         }
         claimants[claimant] = beneficiary;
-    }
-
-    /**
-     * @dev Returns metadata explaining a claim. Subclasses should call this first and return it if it is nonempty.
-     * @return A URL that resolves to JSON metadata as described in the spec.
-     *         Callers must support at least 'data' and 'https' schemes.
-     */
-    function metadata(address /*issuer*/, bytes calldata /*claimData*/, bytes calldata /*executorData*/) public override virtual view returns(string memory) {
-        return "";
     }    
 }

--- a/packages/validator/contracts/ValidatorLib.sol
+++ b/packages/validator/contracts/ValidatorLib.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.10;
 import "@openzeppelin/contracts/contracts/utils/cryptography/ECDSA.sol";
 
 library ValidatorLib {
-    function validate(address validator, address beneficiary, bytes calldata data, bytes calldata authsig, bytes calldata claimsig) internal pure returns(address) {
+  function validate(address validator, address beneficiary, bytes calldata data, bytes calldata authsig, bytes calldata claimsig) internal pure returns(address, address) {
         bytes32 claimhash = keccak256(abi.encodePacked(
             hex"1900",
             validator,
@@ -20,6 +20,7 @@ library ValidatorLib {
             keccak256(data),
             claimant
         ));
-        return ECDSA.recover(authhash, authsig);
+        address issuer = ECDSA.recover(authhash, authsig);
+        return (issuer, claimant);
     }
 }

--- a/packages/validator/contracts/ValidatorRegistry.sol
+++ b/packages/validator/contracts/ValidatorRegistry.sol
@@ -49,11 +49,11 @@ contract ValidatorRegistry is IValidator, ERC165 {
         if(data.length == 0) {
             revert InvalidRequest();
         }
-        address issuer = ValidatorLib.validate(address(this), beneficiary, data, authsig, claimsig);
+        (address issuer, address claimant) = ValidatorLib.validate(address(this), beneficiary, data, authsig, claimsig);
         if(data[0] == CLAIM_REQUEST) {
-            doClaim(issuer, beneficiary, data);
+          doClaim(issuer, claimant, beneficiary, data);
         } else if(data[0] == CONFIG_REQUEST) {
-            doConfigure(issuer, beneficiary, data);
+          doConfigure(issuer, claimant, beneficiary, data);
         } else {
             revert InvalidClaimType(uint8(data[0]));
         }
@@ -124,15 +124,15 @@ contract ValidatorRegistry is IValidator, ERC165 {
         return interfaceId == type(IValidator).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    function doClaim(address issuer, address beneficiary, bytes calldata data) internal {
+    function doClaim(address issuer, address claimant, address beneficiary, bytes calldata data) internal {
         Configuration memory config = configs[issuer];
         if(address(config.executor) == address(0)) {
             revert NotConfigured();
         }
-        config.executor.executeClaim(issuer, beneficiary, data[1:], config.data);
+        config.executor.executeClaim(issuer, claimant, beneficiary, data[1:], config.data);
     }
 
-    function doConfigure(address issuer, address beneficiary, bytes calldata data) internal {
+    function doConfigure(address issuer, address /*claimant*/, address beneficiary, bytes calldata data) internal {
         if(data.length != 33) {
             revert InvalidRequest();
         }

--- a/packages/validator/contracts/ValidatorRegistry.sol
+++ b/packages/validator/contracts/ValidatorRegistry.sol
@@ -63,11 +63,12 @@ contract ValidatorRegistry is IValidator, ERC165 {
     /**
      * @dev Returns metadata explaining a claim.
      * @param issuer The address of the issuer.
+     * @param claimant The account that is entitled to make the claim.
      * @param data Claim data provided by the issuer.
      * @return A URL that resolves to JSON metadata as described in the spec.
      *         Callers must support at least 'data' and 'https' schemes.
      */
-    function metadata(address issuer, bytes calldata data) external view returns(string memory) {
+    function metadata(address issuer, address claimant, bytes calldata data) external view returns(string memory) {
         if(data.length == 0 || (data[0] == CONFIG_REQUEST && data.length != 33)) {
             return string(abi.encodePacked(
                 "data:application/json;base64,",
@@ -81,7 +82,7 @@ contract ValidatorRegistry is IValidator, ERC165 {
                     Base64.encode("{\"valid\":false,\"error\":\"No executor configured for this issuer\"}")
                 ));
             }
-            return config.executor.metadata(issuer, data[1:], config.data);
+            return config.executor.metadata(issuer, claimant, data[1:], config.data);
         } else if(data[0] == CONFIG_REQUEST) {
             Ownership memory owner = owners[issuer];
             uint64 nonce = abi.decode(data[1:], (uint64));

--- a/packages/validator/contracts/test/TestHighestNonceExecutor.sol
+++ b/packages/validator/contracts/test/TestHighestNonceExecutor.sol
@@ -15,12 +15,13 @@ contract TestHighestNonceExecutor is HighestNonceExecutor {
      *      was called by a registry they recognise, and that any conditions in claimData such as replay protection are met
      *      before acting on the request.
      * @param issuer The account that issued the claim.
+     * @param claimant The account that is entitled to make the claim.
      * @param beneficiary The account that the claim should benefit.
      * @param claimData Claim data provided by the issuer.
      * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      */
-    function executeClaim(address issuer, address beneficiary, bytes calldata claimData, bytes calldata executorData) public override {
-        super.executeClaim(issuer, beneficiary, claimData, executorData);
+    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData, bytes calldata executorData) public override {
+        super.executeClaim(issuer, claimant, beneficiary, claimData, executorData);
         emit Claimed(issuer, beneficiary, claimData, executorData);
     }
 

--- a/packages/validator/contracts/test/TestHighestNonceExecutor.sol
+++ b/packages/validator/contracts/test/TestHighestNonceExecutor.sol
@@ -28,13 +28,14 @@ contract TestHighestNonceExecutor is HighestNonceExecutor {
     /**
      * @dev Returns metadata explaining a claim.
      * @param issuer The address of the issuer.
+     * @param claimant The account that is entitled to make the claim.
      * @param claimData Claim data provided by the issuer.
      * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      * @return A URL that resolves to JSON metadata as described in the spec.
      *         Callers must support at least 'data' and 'https' schemes.
      */
-    function metadata(address issuer, bytes calldata claimData, bytes calldata executorData) public override virtual view returns(string memory) {
-        string memory ret = super.metadata(issuer, claimData, executorData);
+    function metadata(address issuer, address claimant, bytes calldata claimData, bytes calldata executorData) public override virtual view returns(string memory) {
+        string memory ret = super.metadata(issuer, claimant, claimData, executorData);
         if(bytes(ret).length > 0) {
             return ret;
         }

--- a/packages/validator/contracts/test/TestSingleClaimantExecutor.sol
+++ b/packages/validator/contracts/test/TestSingleClaimantExecutor.sol
@@ -1,0 +1,45 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "../SingleClaimantExecutor.sol";
+/**
+ * @dev Test implementation of a SingleClaimantExecutor that just logs the fact it was called.
+ */
+contract TestSingleClaimantExecutor is SingleClaimantExecutor {
+    event Claimed(address issuer, address beneficiary, bytes claimData, bytes executorData);
+
+    constructor(address _validator) SingleClaimantExecutor(_validator) { }
+
+    /**
+     * @dev Executes a claim that has been verified by the `ValidatorRegistry`. Implementers must check that this function
+     *      was called by a registry they recognise, and that any conditions in claimData such as replay protection are met
+     *      before acting on the request.
+     * @param issuer The account that issued the claim.
+     * @param beneficiary The account that the claim should benefit.
+     * @param claimData Claim data provided by the issuer.
+     * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
+     */
+    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData, bytes calldata executorData) public override {
+        super.executeClaim(issuer, claimant, beneficiary, claimData, executorData);
+        emit Claimed(issuer, beneficiary, claimData, executorData);
+    }
+
+    /**
+     * @dev Returns metadata explaining a claim.
+     * @param issuer The address of the issuer.
+     * @param claimData Claim data provided by the issuer.
+     * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
+     * @return A URL that resolves to JSON metadata as described in the spec.
+     *         Callers must support at least 'data' and 'https' schemes.
+     */
+    function metadata(address issuer, bytes calldata claimData, bytes calldata executorData) public override virtual view returns(string memory) {
+        string memory ret = super.metadata(issuer, claimData, executorData);
+        if(bytes(ret).length > 0) {
+            return ret;
+        }
+        return string(abi.encodePacked(
+            "data:application/json;base64,",
+            Base64.encode("{\"valid\":true,\"data\":{\"title\":\"Emit an event\"}}")
+        ));
+    }
+}

--- a/packages/validator/contracts/test/TestSingleClaimantExecutor.sol
+++ b/packages/validator/contracts/test/TestSingleClaimantExecutor.sol
@@ -27,13 +27,14 @@ contract TestSingleClaimantExecutor is SingleClaimantExecutor {
     /**
      * @dev Returns metadata explaining a claim.
      * @param issuer The address of the issuer.
+     * @param claimant The account that is entitled to make the claim.
      * @param claimData Claim data provided by the issuer.
      * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      * @return A URL that resolves to JSON metadata as described in the spec.
      *         Callers must support at least 'data' and 'https' schemes.
      */
-    function metadata(address issuer, bytes calldata claimData, bytes calldata executorData) public override virtual view returns(string memory) {
-        string memory ret = super.metadata(issuer, claimData, executorData);
+    function metadata(address issuer, address claimant, bytes calldata claimData, bytes calldata executorData) public override virtual view returns(string memory) {
+        string memory ret = super.metadata(issuer, claimant, claimData, executorData);
         if(bytes(ret).length > 0) {
             return ret;
         }

--- a/packages/validator/test/HighestNonceExecutor.test.ts
+++ b/packages/validator/test/HighestNonceExecutor.test.ts
@@ -33,7 +33,8 @@ describe('HighestNonceExecutor', () => {
         it('emits an event and updates the nonce', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
             const executorData = '0x';
-            const tx = await executor.executeClaim(signers[0].address, signers[1].address, claimData, executorData);
+            const claimant = signers[3].address
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
             const receipt = await tx.wait();
             expect(receipt.events.length).to.equal(1);
             expect(receipt.events[0].event).to.equal('Claimed');
@@ -47,13 +48,15 @@ describe('HighestNonceExecutor', () => {
         it('only allows calls from the validator', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
             const executorData = '0x';
-            await expect(executor.connect(signers[1]).executeClaim(signers[0].address, signers[1].address, claimData, executorData)).to.be.reverted;
+            const claimant = signers[3].address
+            await expect(executor.connect(signers[1]).executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData)).to.be.reverted;
         });
 
         it('allows skipping nonces', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [1]);
             const executorData = '0x';
-            const tx = await executor.executeClaim(signers[0].address, signers[1].address, claimData, executorData);
+            const claimant = signers[3].address
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
             const receipt = await tx.wait();
             expect(receipt.events.length).to.equal(1);
             expect(receipt.events[0].event).to.equal('Claimed');
@@ -62,17 +65,19 @@ describe('HighestNonceExecutor', () => {
         it('reverts if the nonce is too low', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
             const executorData = '0x';
-            const tx = await executor.executeClaim(signers[0].address, signers[1].address, claimData, executorData);
+            const claimant = signers[3].address
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
             const receipt = await tx.wait();
             expect(receipt.events.length).to.equal(1);
             expect(receipt.events[0].event).to.equal('Claimed');
-            await expect(executor.executeClaim(signers[0].address, signers[1].address, claimData, executorData)).to.be.reverted;
+            await expect(executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData)).to.be.reverted;
         });
 
         it('reverts if no nonce is provided', async () => {
             const claimData = '0x';
             const executorData = '0x';
-            await expect(executor.executeClaim(signers[0].address, signers[1].address, claimData, executorData)).to.be.reverted;
+            const claimant = signers[3].address
+            await expect(executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData)).to.be.reverted;
         });
     });
 
@@ -80,6 +85,7 @@ describe('HighestNonceExecutor', () => {
         it('returns valid metadata', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
             const executorData = '0x';
+            const claimant = signers[3].address
             const metadata = parseMetadata(await executor.metadata(signers[0].address, claimData, executorData));
             expect(metadata.valid).to.be.true;
         });
@@ -87,7 +93,8 @@ describe('HighestNonceExecutor', () => {
         it('returns an error in the metadata if the nonce is too low', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
             const executorData = '0x';
-            const tx = await executor.executeClaim(signers[0].address, signers[1].address, claimData, executorData);
+            const claimant = signers[3].address
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
             await tx.wait();
             const metadata = parseMetadata(await executor.metadata(signers[0].address, claimData, executorData));
             expect(metadata.valid).to.be.false;

--- a/packages/validator/test/HighestNonceExecutor.test.ts
+++ b/packages/validator/test/HighestNonceExecutor.test.ts
@@ -85,7 +85,8 @@ describe('HighestNonceExecutor', () => {
         it('returns valid metadata', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
             const executorData = '0x';
-            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimData, executorData));
+            const claimant = signers[3].address            
+            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData, executorData));
             expect(metadata.valid).to.be.true;
         });
 
@@ -95,7 +96,7 @@ describe('HighestNonceExecutor', () => {
             const claimant = signers[3].address
             const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
             await tx.wait();
-            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimData, executorData));
+            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData, executorData));
             expect(metadata.valid).to.be.false;
         });
     });

--- a/packages/validator/test/HighestNonceExecutor.test.ts
+++ b/packages/validator/test/HighestNonceExecutor.test.ts
@@ -85,7 +85,6 @@ describe('HighestNonceExecutor', () => {
         it('returns valid metadata', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
             const executorData = '0x';
-            const claimant = signers[3].address
             const metadata = parseMetadata(await executor.metadata(signers[0].address, claimData, executorData));
             expect(metadata.valid).to.be.true;
         });

--- a/packages/validator/test/SingleClaimantExecutor.test.ts
+++ b/packages/validator/test/SingleClaimantExecutor.test.ts
@@ -63,15 +63,5 @@ describe('SingleClaimantExecutor', () => {
             const claimData2 = defaultAbiCoder.encode(['uint64'], [1]);            
             await expect(executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData2, executorData)).to.be.reverted;
         });
-    });
-
-    describe('metadata()', () => {
-        it('returns valid metadata', async () => {
-            const claimData = defaultAbiCoder.encode(['uint64'], [0]);
-            const executorData = '0x';
-            const claimant = signers[3].address
-            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimData, executorData));
-            expect(metadata.valid).to.be.true;
-        });
-    });
+    });    
 });

--- a/packages/validator/test/SingleClaimantExecutor.test.ts
+++ b/packages/validator/test/SingleClaimantExecutor.test.ts
@@ -1,0 +1,77 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { Contract } from "ethers";
+import { defaultAbiCoder } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+function parseMetadata(datauri: string) {
+    expect(datauri).to.match(/^data:application\/json;base64,/);
+    return JSON.parse(atob(datauri.split(',')[1]));
+}
+
+describe('SingleClaimantExecutor', () => {
+    let signers: SignerWithAddress[];
+    let snapshot: number;
+    let executor: Contract;
+
+    before(async () => {
+        signers = await ethers.getSigners();
+        const TestSingleClaimantExecutor = await ethers.getContractFactory("TestSingleClaimantExecutor");
+        executor = await TestSingleClaimantExecutor.deploy(signers[0].address);
+        await executor.deployed();
+    });
+
+    beforeEach(async () => {
+        snapshot = await ethers.provider.send("evm_snapshot", []);
+    });
+
+    afterEach(async () => {
+        await ethers.provider.send("evm_revert", [snapshot]);
+    })
+
+    describe('executeClaim()', () => {
+        it('emits an event and saves the claimant', async () => {
+            const claimData = defaultAbiCoder.encode(['uint64'], [0]);
+            const executorData = '0x';
+            const claimant = signers[3].address
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
+            const receipt = await tx.wait();
+            expect(receipt.events.length).to.equal(1);
+            expect(receipt.events[0].event).to.equal('Claimed');
+            const args = receipt.events[0].args;
+            expect(args.issuer).to.equal(signers[0].address);
+            expect(args.beneficiary).to.equal(signers[1].address);
+            expect(args.claimData).to.equal(claimData);
+            expect(args.executorData).to.equal(executorData);
+
+            // claimant is saved to beneficiary
+            expect(await executor.claimants(claimant)).to.equal(signers[1].address);
+        });
+
+        it('only allows calls from the validator', async () => {
+            const claimData = defaultAbiCoder.encode(['uint64'], [0]);
+            const executorData = '0x';
+            const claimant = signers[3].address
+            await expect(executor.connect(signers[1]).executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData)).to.be.reverted;
+        });
+
+        it('reverts if claimant was used', async () => {
+            const claimData = defaultAbiCoder.encode(['uint64'], [0]);
+            const executorData = '0x';
+            const claimant = signers[3].address
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
+            const claimData2 = defaultAbiCoder.encode(['uint64'], [1]);            
+            await expect(executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData2, executorData)).to.be.reverted;
+        });
+    });
+
+    describe('metadata()', () => {
+        it('returns valid metadata', async () => {
+            const claimData = defaultAbiCoder.encode(['uint64'], [0]);
+            const executorData = '0x';
+            const claimant = signers[3].address
+            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimData, executorData));
+            expect(metadata.valid).to.be.true;
+        });
+    });
+});

--- a/packages/validator/test/SingleClaimantExecutor.test.ts
+++ b/packages/validator/test/SingleClaimantExecutor.test.ts
@@ -60,8 +60,28 @@ describe('SingleClaimantExecutor', () => {
             const executorData = '0x';
             const claimant = signers[3].address
             const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
-            const claimData2 = defaultAbiCoder.encode(['uint64'], [1]);            
+            const claimData2 = defaultAbiCoder.encode(['uint64'], [1]);
             await expect(executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData2, executorData)).to.be.reverted;
         });
-    });    
+    });
+
+    describe('metadata()', () => {
+        it('returns valid metadata', async () => {
+            const claimData = '0x';
+            const executorData = '0x';
+            const claimant = signers[3].address
+            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData, executorData));
+            expect(metadata.valid).to.be.true;
+        });
+
+        it('returns an error in the metadata if the claimant was already used', async () => {
+            const claimData = '0x';
+            const executorData = '0x';
+            const claimant = signers[3].address
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
+            await tx.wait();
+            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData, executorData));
+            expect(metadata.valid).to.be.false;
+        });
+    });
 });

--- a/packages/validator/test/ValidatorRegistry.test.ts
+++ b/packages/validator/test/ValidatorRegistry.test.ts
@@ -174,7 +174,7 @@ describe('ValidatorRegistry', () => {
             await tx.wait();
             const tx2 = await validator.configure(issueraddress, executor.address, '0x');
             await tx2.wait();
-            
+
             const claimcode = issuer.makeClaimCode();
 
             const metadata = parseMetadata(await validator.metadata(issueraddress, claimcode.claimant, claimcode.data));

--- a/packages/validator/test/ValidatorRegistry.test.ts
+++ b/packages/validator/test/ValidatorRegistry.test.ts
@@ -176,7 +176,6 @@ describe('ValidatorRegistry', () => {
             await tx2.wait();
 
             const claimcode = issuer.makeClaimCode();
-
             const metadata = parseMetadata(await validator.metadata(issueraddress, claimcode.claimant, claimcode.data));
             expect(metadata.valid).to.be.true;
             expect(metadata.data.title).to.equal('Emit an event');


### PR DESCRIPTION
Single-use claimant executor implemented according to https://gist.github.com/Arachnid/df9c7e3738ee76bf171c46ef38e4f18b#single-use-claimant-addresses

Had to change contracts/ValidatorLib.sol to return claimant and added `claimant` param to `executor.executeClaim`. 