### PR TITLE
Add claimAndConfigure; add executor configuration pass through

### DIFF
--- a/packages/validator/contracts/BaseExecutor.sol
+++ b/packages/validator/contracts/BaseExecutor.sol
@@ -19,17 +19,24 @@ abstract contract BaseExecutor is IExecutor, ERC165 {
         validator = _validator;
     }
 
-    function executeClaim(address /*issuer*/, address /*claimant*/, address /*beneficiary*/, bytes calldata /*claimData*/, bytes calldata /*executorData*/) public virtual override {
+    modifier validatorOnly {
         if(msg.sender != validator) {
             revert NotAuthorisedError();
         }
+        _;
+    }
+
+    function executeClaim(address /*issuer*/, address /*claimant*/, address /*beneficiary*/, bytes calldata /*claimData*/) public virtual override  validatorOnly {
     }
 
     function supportsInterface(bytes4 interfaceId) public view override(IERC165, ERC165) returns(bool) {
         return interfaceId == type(IExecutor).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    function metadata(address /*issuer*/, address /*claimant*/, bytes calldata /*claimData*/, bytes calldata /*executorData*/) public override virtual view returns(string memory) {
+    function metadata(address /*issuer*/, address /*claimant*/, bytes calldata /*claimData*/) public override virtual view returns(string memory) {
         revert NotImplementedError();
+    }
+
+    function configure(address /*issuer*/, address /*owner*/, bytes calldata /*data*/) public virtual override validatorOnly {
     }
 }

--- a/packages/validator/contracts/HighestNonceExecutor.sol
+++ b/packages/validator/contracts/HighestNonceExecutor.sol
@@ -25,10 +25,9 @@ abstract contract HighestNonceExecutor is BaseExecutor {
      * @param claimant The account that is entitled to make the claim.
      * @param beneficiary The account that the claim should benefit.
      * @param claimData Claim data provided by the issuer.
-     * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      */
-    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData, bytes calldata executorData) public virtual override {
-        super.executeClaim(issuer, claimant, beneficiary, claimData, executorData);
+    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData) public virtual override {
+        super.executeClaim(issuer, claimant, beneficiary, claimData);
         uint64 claimNonce = abi.decode(claimData, (uint64));
         if(claimNonce < nonce) {
             revert NonceTooLow();
@@ -42,7 +41,7 @@ abstract contract HighestNonceExecutor is BaseExecutor {
      * @return A URL that resolves to JSON metadata as described in the spec.
      *         Callers must support at least 'data' and 'https' schemes.
      */
-    function metadata(address /*issuer*/, address /*claimaint*/, bytes calldata claimData, bytes calldata /*executorData*/) public override virtual view returns(string memory) {
+    function metadata(address /*issuer*/, address /*claimaint*/, bytes calldata claimData) public override virtual view returns(string memory) {
         uint64 claimNonce = abi.decode(claimData, (uint64));
         if(claimNonce < nonce) {
             return string(abi.encodePacked(

--- a/packages/validator/contracts/IExecutor.sol
+++ b/packages/validator/contracts/IExecutor.sol
@@ -19,18 +19,24 @@ interface IExecutor is IERC165 {
      * @param claimant The account that is entitled to make the claim.
      * @param beneficiary The account that the claim should benefit.
      * @param claimData Claim data provided by the issuer.
-     * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      */
-    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData, bytes calldata executorData) external;
+    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData) external;
 
     /**
      * @dev Returns metadata explaining a claim.
      * @param issuer The address of the issuer.
      * @param claimant The account that is entitled to make the claim.
      * @param claimData Claim data provided by the issuer.
-     * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      * @return A URL that resolves to JSON metadata as described in the spec.
      *         Callers must support at least 'data' and 'https' schemes.
      */
-    function metadata(address issuer, address claimant,bytes calldata claimData, bytes calldata executorData) external view returns(string memory);
+    function metadata(address issuer, address claimant, bytes calldata claimData) external view returns(string memory);
+
+    /**
+     * @dev Configures an issuer for this contract. Callable only by the `ValidatorRegistry`.
+     * @param issuer The issuer that is being configured.
+     * @param owner The address that owns this issuer in the `ValidatorRegistry`.
+     * @param data The user-supplied data for this executor.
+     */
+    function configure(address issuer, address owner, bytes calldata data) external;
 }

--- a/packages/validator/contracts/IValidator.sol
+++ b/packages/validator/contracts/IValidator.sol
@@ -14,8 +14,9 @@ interface IValidator is IERC165 {
      * @param data Claim data provided by the issuer.
      * @param authsig A signature over the authorisation message, produced by the issuer.
      * @param claimsig A signature over the claim message, produced by the client.
+     * @return The address of the issuer for this claim.
      */
-    function claim(address beneficiary, bytes calldata data, bytes calldata authsig, bytes calldata claimsig) external;
+    function claim(address beneficiary, bytes calldata data, bytes calldata authsig, bytes calldata claimsig) external returns(address);
 
     /**
      * @dev Returns metadata explaining a claim.

--- a/packages/validator/contracts/SingleClaimantExecutor.sol
+++ b/packages/validator/contracts/SingleClaimantExecutor.sol
@@ -26,10 +26,9 @@ abstract contract SingleClaimantExecutor is BaseExecutor {
      * @param claimant The account that is entitled to make the claim.
      * @param beneficiary The account that the claim should benefit.
      * @param claimData Claim data provided by the issuer.
-     * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      */
-    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData, bytes calldata executorData) public virtual override {
-        super.executeClaim(issuer, claimant, beneficiary, claimData, executorData);
+    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData) public virtual override {
+        super.executeClaim(issuer, claimant, beneficiary, claimData);
 
         // if claimant was already used
         if(claimants[claimant] != address(0)) {
@@ -44,7 +43,7 @@ abstract contract SingleClaimantExecutor is BaseExecutor {
      * @return A URL that resolves to JSON metadata as described in the spec.
      *         Callers must support at least 'data' and 'https' schemes.
      */
-    function metadata(address /*issuer*/, address claimant, bytes calldata /*claimData*/, bytes calldata /*executorData*/) public override virtual view returns(string memory) {
+    function metadata(address /*issuer*/, address claimant, bytes calldata /*claimData*/) public override virtual view returns(string memory) {
       if(claimants[claimant] != address(0)) {
         return string(abi.encodePacked(
                                        "data:application/json;base64,",

--- a/packages/validator/contracts/test/TestHighestNonceExecutor.sol
+++ b/packages/validator/contracts/test/TestHighestNonceExecutor.sol
@@ -6,7 +6,7 @@ import "../HighestNonceExecutor.sol";
  * @dev Test implementation of a HighestNonceExecutor that just logs the fact it was called.
  */
 contract TestHighestNonceExecutor is HighestNonceExecutor {
-    event Claimed(address issuer, address beneficiary, bytes claimData, bytes executorData);
+    event Claimed(address issuer, address beneficiary, bytes claimData);
 
     constructor(address _validator) HighestNonceExecutor(_validator) { }
 
@@ -18,11 +18,10 @@ contract TestHighestNonceExecutor is HighestNonceExecutor {
      * @param claimant The account that is entitled to make the claim.
      * @param beneficiary The account that the claim should benefit.
      * @param claimData Claim data provided by the issuer.
-     * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      */
-    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData, bytes calldata executorData) public override {
-        super.executeClaim(issuer, claimant, beneficiary, claimData, executorData);
-        emit Claimed(issuer, beneficiary, claimData, executorData);
+    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData) public override {
+        super.executeClaim(issuer, claimant, beneficiary, claimData);
+        emit Claimed(issuer, beneficiary, claimData);
     }
 
     /**
@@ -30,12 +29,11 @@ contract TestHighestNonceExecutor is HighestNonceExecutor {
      * @param issuer The address of the issuer.
      * @param claimant The account that is entitled to make the claim.
      * @param claimData Claim data provided by the issuer.
-     * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      * @return A URL that resolves to JSON metadata as described in the spec.
      *         Callers must support at least 'data' and 'https' schemes.
      */
-    function metadata(address issuer, address claimant, bytes calldata claimData, bytes calldata executorData) public override virtual view returns(string memory) {
-        string memory ret = super.metadata(issuer, claimant, claimData, executorData);
+    function metadata(address issuer, address claimant, bytes calldata claimData) public override virtual view returns(string memory) {
+        string memory ret = super.metadata(issuer, claimant, claimData);
         if(bytes(ret).length > 0) {
             return ret;
         }

--- a/packages/validator/contracts/test/TestSingleClaimantExecutor.sol
+++ b/packages/validator/contracts/test/TestSingleClaimantExecutor.sol
@@ -6,7 +6,7 @@ import "../SingleClaimantExecutor.sol";
  * @dev Test implementation of a SingleClaimantExecutor that just logs the fact it was called.
  */
 contract TestSingleClaimantExecutor is SingleClaimantExecutor {
-    event Claimed(address issuer, address beneficiary, bytes claimData, bytes executorData);
+    event Claimed(address issuer, address beneficiary, bytes claimData);
 
     constructor(address _validator) SingleClaimantExecutor(_validator) { }
 
@@ -17,11 +17,10 @@ contract TestSingleClaimantExecutor is SingleClaimantExecutor {
      * @param issuer The account that issued the claim.
      * @param beneficiary The account that the claim should benefit.
      * @param claimData Claim data provided by the issuer.
-     * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      */
-    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData, bytes calldata executorData) public override {
-        super.executeClaim(issuer, claimant, beneficiary, claimData, executorData);
-        emit Claimed(issuer, beneficiary, claimData, executorData);
+    function executeClaim(address issuer, address claimant, address beneficiary, bytes calldata claimData) public override {
+        super.executeClaim(issuer, claimant, beneficiary, claimData);
+        emit Claimed(issuer, beneficiary, claimData);
     }
 
     /**
@@ -29,12 +28,11 @@ contract TestSingleClaimantExecutor is SingleClaimantExecutor {
      * @param issuer The address of the issuer.
      * @param claimant The account that is entitled to make the claim.
      * @param claimData Claim data provided by the issuer.
-     * @param executorData Contextual information stored on the ValidatorRegistry for this issuer.
      * @return A URL that resolves to JSON metadata as described in the spec.
      *         Callers must support at least 'data' and 'https' schemes.
      */
-    function metadata(address issuer, address claimant, bytes calldata claimData, bytes calldata executorData) public override virtual view returns(string memory) {
-        string memory ret = super.metadata(issuer, claimant, claimData, executorData);
+    function metadata(address issuer, address claimant, bytes calldata claimData) public override virtual view returns(string memory) {
+        string memory ret = super.metadata(issuer, claimant, claimData);
         if(bytes(ret).length > 0) {
             return ret;
         }

--- a/packages/validator/test/HighestNonceExecutor.test.ts
+++ b/packages/validator/test/HighestNonceExecutor.test.ts
@@ -32,9 +32,8 @@ describe('HighestNonceExecutor', () => {
     describe('executeClaim()', () => {
         it('emits an event and updates the nonce', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
-            const executorData = '0x';
             const claimant = signers[3].address
-            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData);
             const receipt = await tx.wait();
             expect(receipt.events.length).to.equal(1);
             expect(receipt.events[0].event).to.equal('Claimed');
@@ -42,21 +41,19 @@ describe('HighestNonceExecutor', () => {
             expect(args.issuer).to.equal(signers[0].address);
             expect(args.beneficiary).to.equal(signers[1].address);
             expect(args.claimData).to.equal(claimData);
-            expect(args.executorData).to.equal(executorData);
         });
 
         it('only allows calls from the validator', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
             const executorData = '0x';
             const claimant = signers[3].address
-            await expect(executor.connect(signers[1]).executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData)).to.be.reverted;
+            await expect(executor.connect(signers[1]).executeClaim(signers[0].address, claimant, signers[1].address, claimData)).to.be.reverted;
         });
 
         it('allows skipping nonces', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [1]);
-            const executorData = '0x';
             const claimant = signers[3].address
-            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData);
             const receipt = await tx.wait();
             expect(receipt.events.length).to.equal(1);
             expect(receipt.events[0].event).to.equal('Claimed');
@@ -64,39 +61,35 @@ describe('HighestNonceExecutor', () => {
 
         it('reverts if the nonce is too low', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
-            const executorData = '0x';
             const claimant = signers[3].address
-            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData);
             const receipt = await tx.wait();
             expect(receipt.events.length).to.equal(1);
             expect(receipt.events[0].event).to.equal('Claimed');
-            await expect(executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData)).to.be.reverted;
+            await expect(executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData)).to.be.reverted;
         });
 
         it('reverts if no nonce is provided', async () => {
             const claimData = '0x';
-            const executorData = '0x';
             const claimant = signers[3].address
-            await expect(executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData)).to.be.reverted;
+            await expect(executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData)).to.be.reverted;
         });
     });
 
     describe('metadata()', () => {
         it('returns valid metadata', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
-            const executorData = '0x';
             const claimant = signers[3].address            
-            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData, executorData));
+            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData));
             expect(metadata.valid).to.be.true;
         });
 
         it('returns an error in the metadata if the nonce is too low', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
-            const executorData = '0x';
             const claimant = signers[3].address
-            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData);
             await tx.wait();
-            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData, executorData));
+            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData));
             expect(metadata.valid).to.be.false;
         });
     });

--- a/packages/validator/test/SingleClaimantExecutor.test.ts
+++ b/packages/validator/test/SingleClaimantExecutor.test.ts
@@ -32,9 +32,8 @@ describe('SingleClaimantExecutor', () => {
     describe('executeClaim()', () => {
         it('emits an event and saves the claimant', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
-            const executorData = '0x';
             const claimant = signers[3].address
-            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData);
             const receipt = await tx.wait();
             expect(receipt.events.length).to.equal(1);
             expect(receipt.events[0].event).to.equal('Claimed');
@@ -42,7 +41,6 @@ describe('SingleClaimantExecutor', () => {
             expect(args.issuer).to.equal(signers[0].address);
             expect(args.beneficiary).to.equal(signers[1].address);
             expect(args.claimData).to.equal(claimData);
-            expect(args.executorData).to.equal(executorData);
 
             // claimant is saved to beneficiary
             expect(await executor.claimants(claimant)).to.equal(signers[1].address);
@@ -50,37 +48,33 @@ describe('SingleClaimantExecutor', () => {
 
         it('only allows calls from the validator', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
-            const executorData = '0x';
             const claimant = signers[3].address
-            await expect(executor.connect(signers[1]).executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData)).to.be.reverted;
+            await expect(executor.connect(signers[1]).executeClaim(signers[0].address, claimant, signers[1].address, claimData)).to.be.reverted;
         });
 
         it('reverts if claimant was used', async () => {
             const claimData = defaultAbiCoder.encode(['uint64'], [0]);
-            const executorData = '0x';
             const claimant = signers[3].address
-            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData);
             const claimData2 = defaultAbiCoder.encode(['uint64'], [1]);
-            await expect(executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData2, executorData)).to.be.reverted;
+            await expect(executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData2)).to.be.reverted;
         });
     });
 
     describe('metadata()', () => {
         it('returns valid metadata', async () => {
             const claimData = '0x';
-            const executorData = '0x';
             const claimant = signers[3].address
-            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData, executorData));
+            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData));
             expect(metadata.valid).to.be.true;
         });
 
         it('returns an error in the metadata if the claimant was already used', async () => {
             const claimData = '0x';
-            const executorData = '0x';
             const claimant = signers[3].address
-            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData, executorData);
+            const tx = await executor.executeClaim(signers[0].address, claimant, signers[1].address, claimData);
             await tx.wait();
-            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData, executorData));
+            const metadata = parseMetadata(await executor.metadata(signers[0].address, claimant, claimData));
             expect(metadata.valid).to.be.false;
         });
     });


### PR DESCRIPTION
This PR makes a few changes to the `ValidatorRegistry` and associated plumbing:
 1. Adds a `configure` method to `IExecutor`, callable only by the `ValidatorRegistry` to allow configuring an executor in the same transaction as the user setting the executor.
 2. Removes the `executorData` stored by the `ValidatorRegistry`
 3. Makes the `configure` method on `ValidatorRegistry` call `configure` on the newly set executor, passing in the data provided.
 4. Adds a `claimAndConfigure` method that submits a claim and then a configuration request, so users can set up a new issuer entirely in a single transaction.
