### PR TITLE
Shibboleth-js auto recover issuer

### DIFF
--- a/packages/shibboleth-js/src/index.ts
+++ b/packages/shibboleth-js/src/index.ts
@@ -94,7 +94,6 @@ export class ClaimCode {
         );
         const r = hexDataSlice(this.authsig, 0, 32);
         const _vs = hexDataSlice(this.authsig, 32);
-        //const splittedSignature = splitSignature({ r, _vs });
         const issuer = recoverAddress(authhash, { r, _vs });
         return issuer;
     }

--- a/packages/shibboleth-js/src/index.ts
+++ b/packages/shibboleth-js/src/index.ts
@@ -120,8 +120,6 @@ export abstract class AbstractIssuer {
         const authsig = this.privateKey.signDigest(authhash);
         return new ClaimCode(this.validator, claimseed, concat([authsig.r, authsig._vs]), data);
     }
-
-
 }
 
 export enum ClaimType {


### PR DESCRIPTION
Added auto-recovery of `issuer` address within ClaimCode initialization. 
It's useful to have automatically pre-computed  `issuer` as it's needed to call `Validator.metadata()` function.